### PR TITLE
Moved the config into the config folder.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Simply open the Kosmos toolbox, go to the sysmodule menu and continue to the hid
 After that a screen will pop up in which you can select the button you want to rebind and then what you want it to rebind for.  
 After you're done, be sure to touch the button in the middle to save your changes.
 
-You can also configure it manually by editing the `/modules/hid_mitm/config.ini` file.
+You can also configure it manually by editing the `/config/hid_mitm/config.ini` file.
 
 ## Custom gamepads
 The way that custom gamepads work with hid-mitm is not by directly connecting the gamepad to your switch but by connecting your gamepad to your phone (and experimentally pc) and then running the hid-mitm app which then in turn sends the input to your switch which will recognize it as an additional pro-controller.

--- a/hid_mitm/build.sh
+++ b/hid_mitm/build.sh
@@ -15,8 +15,8 @@ pushd ..
 make -j
 popd
 mkdir -p out/atmosphere/titles/0100000000000faf/flags
-mkdir -p out/modules/hid_mitm
-cp config.ini out/modules/hid_mitm
+mkdir -p out/config/hid_mitm
+cp config.ini out/config/hid_mitm
 touch out/atmosphere/titles/0100000000000faf/flags/boot2.flag
 cp hid_mitm.nsp out/atmosphere/titles/0100000000000faf/exefs.nsp
 cp start.bat tools/

--- a/hid_mitm/source/hid_mitm_iappletresource.cpp
+++ b/hid_mitm/source/hid_mitm_iappletresource.cpp
@@ -111,7 +111,7 @@ void loadConfig()
 {
     mutexLock(&configMutex);
     rebind_config.clear();
-    if (ini_parse("/modules/hid_mitm/config.ini", handler, NULL) < 0)
+    if (ini_parse("/config/hid_mitm/config.ini", handler, NULL) < 0)
     {
         //fatalSimple(MAKERESULT(321, 1)); // 2321-0001 bad config
     }


### PR DESCRIPTION
Wasn't able to test this to make sure this worked. However seeing as modules is no longer used by Kosmos, and other apps are using `config` it only makes sense to move toward the config folder for sys-modules.

Side note: Wasn't able to test this on my Switch as it appears when hid_mitm is enabled on 8.0.0 you aren't able to get past the Nintendo Switch boot screen.